### PR TITLE
Add multi-platform PyPI publishing

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -3,36 +3,85 @@ name: Python CI
 on:
   push:
     branches: [ main ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ main ]
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
+      
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install build deps
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install maturin pytest numpy
+          python -m pip install --upgrade pip maturin pytest numpy
 
-      - name: Build wheel (Rust -> Python)
-        run: |
-          maturin build --release --features python
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist --features python
+          sccache: 'true'
 
-      - name: Install wheel into runner Python
+      - name: Install wheel
         run: |
-          pip install --force-reinstall target/wheels/*.whl
+          pip install --find-links dist --force-reinstall copyforward
 
-      - name: Run pytest
-        run: |
-          pytest -q
+      - name: Test
+        run: pytest -q
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-wheels, build-sdist]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/copyforward
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "copyforward"
+authors = [{name = "Sean Gallagher"}]
+description = "Fast similarity search using forward-looking LSH"
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "numpy>=1.20",
+]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/SeanTater/copyforward"
+Repository = "https://github.com/SeanTater/copyforward"
+
+[tool.maturin]
+features = ["python"]


### PR DESCRIPTION
## Summary
- Expand CI matrix to build wheels on Linux, macOS, Windows with Python 3.10-3.12
- Add automatic PyPI publishing on version tags using trusted publishing (no API keys needed)
- Add pyproject.toml with proper metadata and dependencies

## Changes
- Updated `.github/workflows/python-ci.yml` with multi-platform matrix
- Added `pyproject.toml` for Python packaging metadata
- Configured trusted publishing workflow for secure PyPI releases

## Test plan
- [ ] Verify CI builds pass on all platforms
- [ ] Set up trusted publisher on PyPI (see README for steps)
- [ ] Test release by creating a version tag

🤖 Generated with [Claude Code](https://claude.ai/code)